### PR TITLE
Dynamic satellites handling

### DIFF
--- a/include/UI/Texture.h
+++ b/include/UI/Texture.h
@@ -1,14 +1,14 @@
 #pragma once
 #include <SDL_image.h>
+#include <memory>
 
 class Texture {
 public:
     Texture(SDL_Texture *texture);
-
+    Texture(const Texture& other);
     ~Texture();
-
-    void render(SDL_Renderer *renderer, const SDL_FRect *pos);
-
+    Texture& operator=(const Texture& other);
+    void render(SDL_Renderer *renderer, const SDL_FRect *pos) const;
 private:
-    SDL_Texture *texture;
+    std::shared_ptr<SDL_Texture> texture;
 };

--- a/source/UI/Texture.cpp
+++ b/source/UI/Texture.cpp
@@ -1,16 +1,19 @@
 #include "Texture.h"
+#include <memory>
 
 Texture::Texture(SDL_Texture* texture)
-{
-    this->texture = texture;
+    : texture(std::shared_ptr<SDL_Texture>(texture, SDL_DestroyTexture)) {}
+
+Texture::~Texture() = default;
+
+Texture::Texture(const Texture& other) : texture(other.texture) {}
+
+Texture& Texture::operator=(const Texture& other) {
+    if (this == &other) return *this;
+    texture = other.texture;
+    return *this;
 }
 
-Texture::~Texture()
-{
-    if(texture) SDL_DestroyTexture(texture);
-}
-
-void Texture::render(SDL_Renderer* renderer, const SDL_FRect* pos)
-{
-    SDL_RenderCopyF(renderer, texture, NULL, pos);
+void Texture::render(SDL_Renderer* renderer, const SDL_FRect* pos) const {
+    SDL_RenderCopyF(renderer, texture.get(), nullptr, pos);
 }

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -20,13 +20,9 @@ UI::~UI() {
 void UI::run(const int &speed) {
     init(width, height);
     Texture background = createTexture("2k_earth_daymap");
-    //vector<Texture> satelliteTextures;
-    //vector<SDL_FRect> satelliteUIElements;
-    Texture satTexture1 = createTexture(sniffer.getSatellites()[0].getTLE().name);
-    Texture satTexture2 = createTexture(sniffer.getSatellites()[1].getTLE().name);
-    SDL_FRect satRect1 = createSatelliteRect();
-    SDL_FRect satRect2 = createSatelliteRect();
-    //createSatelliteUIElements(satelliteTextures, satelliteUIElements);
+    std::vector<Texture> satelliteTextures;
+    std::vector<SDL_FRect> satelliteUIElements;
+    createSatelliteUIElements(satelliteTextures, satelliteUIElements);
 
     SDL_Delay(100);
     bool quit = false;
@@ -39,16 +35,11 @@ void UI::run(const int &speed) {
         quit = handleEvents();
 
         SDL_RenderClear(renderer);
-        renderTexture(background, nullptr);
-        renderTexture(satTexture1, &satRect1);
-        renderTexture(satTexture2, &satRect2);
-        //renderTextures(background, satelliteTextures, satelliteUIElements);
+        renderTextures(background, satelliteTextures, satelliteUIElements);
         SDL_RenderPresent(renderer);
 
         sniffer.updatePositions(width, height, updateTime);
-        updatePosition(sniffer.getSatellites()[0].getXY(), satRect1);
-        updatePosition(sniffer.getSatellites()[1].getXY(), satRect2);
-        //updatePositions(satelliteUIElements);
+        updatePositions(satelliteUIElements);
 
         while (timePassed + timeStep > SDL_GetTicks()) {
             SDL_Delay(1000);


### PR DESCRIPTION
To be able to organize your satelites into collection I did some modification:
- implement smart pointer into Textures instead of row pointer
> std::shared_ptr is a smart pointer that automatically manages the lifetime of the resource it holds. In SDL, SDL_Texture objects need to be manually freed using SDL_DestroyTexture. By using std::shared_ptr, we ensure that SDL_Texture objects are properly managed and freed when no longer needed.
- implement copy and operator= to be able to correctly pass class objects into collection
> A copy constructor is a special constructor that is called when an object is initialized with another object. 
> The copy assignment operator (operator=) is called when an existing object is assigned the value of another existing object.